### PR TITLE
Add asttokens 2.0.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,14 @@ build:
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
     - setuptools >=44
     - setuptools_scm >=3.4.3
     - toml
+    - wheel
   run:
-    - python >=3.5
+    - python
     - six
 
 test:
@@ -38,6 +39,7 @@ about:
   license_file: LICENSE
   summary: The asttokens module annotates Python abstract syntax trees (ASTs) with the positions of tokens and text in the source code that generated them.
   dev_url: https://github.com/gristlabs/asttokens
+  doc_url: https://asttokens.readthedocs.io/en/latest/index.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv 
 
 requirements:
   host:


### PR DESCRIPTION
License: https://github.com/gristlabs/asttokens/blob/v2.0.5/LICENSE
Requirements: 
- https://github.com/gristlabs/asttokens/blob/v2.0.5/setup.cfg
- https://github.com/gristlabs/asttokens/blob/v2.0.5/pyproject.toml

1. Fix python, 
2. Add wheel
3. Add doc_url