### PR TITLE
asttokens 3.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   skip: true  # [py<38]
+  script_env:
+    - SETUPTOOLS_SCM_PRETEND_VERSION={{version}}
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - wheel
   run:
     - python
-    - six
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - setuptools >=44
     - setuptools_scm >=3.4.3
     - toml
+    - wheel
   run:
     - python
     - six
@@ -29,6 +30,10 @@ requirements:
 test:
   imports:
     - asttokens
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/gristlabs/asttokens

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - wheel
   run:
     - python
+  run_constrained:
+    - astroid >=2, <4
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "asttokens" %}
-{% set version = "2.0.5" %}
-{% set sha256 = "9a54c114f02c7a9480d56550932546a3f1fe71d8a02f1bc7ccd0ee3ee35cf4d5" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -9,22 +8,22 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: true  # [py<38]
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
     - setuptools >=44
     - setuptools_scm >=3.4.3
     - toml
   run:
-    - python >=3.5
+    - python
     - six
 
 test:
@@ -37,7 +36,11 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: The asttokens module annotates Python abstract syntax trees (ASTs) with the positions of tokens and text in the source code that generated them.
+  description: |
+    The asttokens module annotates Python abstract syntax trees (ASTs) with the positions of tokens and text in the source code that generated them.
+    It provides a way to access the original source code from the AST, which can be useful for debugging, code analysis, and other tasks.
   dev_url: https://github.com/gristlabs/asttokens
+  doc_url: https://github.com/gristlabs/asttokens
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
> ## ☆ asttokens 3.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6557) 
[Upstream](https://github.com/gristlabs/asttokens)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.8
> *  Updated `about` section